### PR TITLE
[codex] Parallelize release package builds

### DIFF
--- a/.github/workflows/ReleasePackage.yml
+++ b/.github/workflows/ReleasePackage.yml
@@ -20,18 +20,15 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  metadata:
     runs-on: windows-2022
-    env:
-      SOLUTION_FILE_PATH: project/CalyxEngine.sln
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      package_name: ${{ steps.release.outputs.package_name }}
+      prerelease: ${{ steps.release.outputs.prerelease }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
-
       - name: Resolve release metadata
         id: release
         shell: pwsh
@@ -59,34 +56,73 @@ jobs:
           "version=$version" >> $env:GITHUB_OUTPUT
           "tag_name=$tagName" >> $env:GITHUB_OUTPUT
           "package_name=CalyxGamePackage-$tagName.zip" >> $env:GITHUB_OUTPUT
+          "prerelease=${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || false }}" >> $env:GITHUB_OUTPUT
+
+  build:
+    needs: metadata
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [Debug, Develop, Release]
+    env:
+      SOLUTION_FILE_PATH: project/CalyxEngine.sln
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.metadata.outputs.tag_name }}
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v2
         with:
           msbuild-architecture: x64
 
-      - name: Build Debug
-        run: msbuild $env:SOLUTION_FILE_PATH /m /p:Platform=x64 /p:Configuration=Debug
+      - name: Build ${{ matrix.configuration }}
+        run: msbuild $env:SOLUTION_FILE_PATH /m /p:Platform=x64 /p:Configuration=${{ matrix.configuration }}
 
-      - name: Build Develop
-        run: msbuild $env:SOLUTION_FILE_PATH /m /p:Platform=x64 /p:Configuration=Develop
+      - name: Upload ${{ matrix.configuration }} outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: calyx-build-${{ matrix.configuration }}
+          if-no-files-found: error
+          path: |
+            generated/outputs/${{ matrix.configuration }}/**
+            project/generated/bin/DirectXTex/x64/Debug/**
+            project/generated/bin/DirectXTex/x64/Release/**
 
-      - name: Build Release
-        run: msbuild $env:SOLUTION_FILE_PATH /m /p:Platform=x64 /p:Configuration=Release
+  release:
+    needs: [metadata, build]
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.metadata.outputs.tag_name }}
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: calyx-build-*
+          merge-multiple: true
 
       - name: Create package
         shell: pwsh
         run: |
           ./project/Tools/PackageCalyxEngine.ps1 `
-            -Version "${{ steps.release.outputs.tag_name }}" `
+            -Version "${{ needs.metadata.outputs.tag_name }}" `
             -Configuration Develop `
             -OutputRoot "$env:GITHUB_WORKSPACE/generated/packages"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.release.outputs.tag_name }}
-          name: CalyxEngine ${{ steps.release.outputs.version }}
-          prerelease: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || false }}
+          tag_name: ${{ needs.metadata.outputs.tag_name }}
+          name: CalyxEngine ${{ needs.metadata.outputs.version }}
+          prerelease: ${{ needs.metadata.outputs.prerelease }}
           generate_release_notes: true
-          files: generated/packages/${{ steps.release.outputs.package_name }}
+          files: generated/packages/${{ needs.metadata.outputs.package_name }}


### PR DESCRIPTION
## Summary

- Split the ReleasePackage workflow into metadata, parallel build, and release jobs.
- Build Debug, Develop, and Release with a matrix instead of running them serially.
- Upload each configuration's build outputs as artifacts and download them before packaging.

## Why

The package workflow needs all three configurations for the SDK package, but they do not need to run one after another. Running them in parallel reduces waiting time and makes configuration-specific failures easier to identify.

## Validation

- Inspected the workflow diff locally.
- Did not run GitHub Actions locally; the workflow will be validated by the next Actions run.